### PR TITLE
Precedence fix

### DIFF
--- a/shared/src/main/scala/scala/util/parsing/combinator/Parsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/Parsers.scala
@@ -1113,7 +1113,10 @@ trait Parsers {
               case Success(rhs, next) => {
                 expandRight(rhs, next, prec) match {
                   case Right(Success(r, rnext)) => {
-                    expandLeft(makeBinop(lhs, op, r), rnext, minLevel)
+                    expandLeft(makeBinop(lhs, op, r), rnext, minLevel) match {
+                      case Left(s: Success[Exp]) => Right(s)
+                      case result => result
+                    }
                   }
                   case Left(Success(r, rnext)) => Left(Success(makeBinop(lhs, op, r), rnext))
                 }

--- a/shared/src/test/scala/scala/util/parsing/combinator/PrecedenceParserTest.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/PrecedenceParserTest.scala
@@ -99,5 +99,6 @@ class PrecedenceParsersTest {
     testExp(Binop(Leaf(3), Plus, Binop(Leaf(9), Divide, Leaf(11))), "3 + 9 / 11")
     testExp(Binop(Binop(Leaf(6), Plus, Leaf(8)), Equals, Leaf(1)), "6 + 8 = 1")
     testExp(Binop(Leaf(4), Equals, Binop(Leaf(5), Minus, Leaf(3))), "4 = 5 - 3")
+    testExp(Binop(Binop(Leaf(1), Minus, Binop(Leaf(2), Mult, Leaf(3))), Plus, Leaf(4)), "1 - 2 * 3 + 4")
   }
 }


### PR DESCRIPTION
I discovered that in some cases, a dangling operator could cause nontermination. In the process of fixing it, I made an attempt to rewrite it in what I hope is simpler and more idiomatic code.

Feedback is welcome, especially on ways this code could be made more legible.